### PR TITLE
solving unknown file attribute error

### DIFF
--- a/pkg/kubectl/cmd/completion.go
+++ b/pkg/kubectl/cmd/completion.go
@@ -258,6 +258,7 @@ fi
 __kubectl_convert_bash_to_zsh() {
 	sed \
 	-e 's/declare -F/whence -w/' \
+	-e 's/\$\@/\$\{\*\}/' \
 	-e 's/local \([a-zA-Z0-9_]*\)=/local \1; \1=/' \
 	-e 's/flags+=("\(--.*\)=")/flags+=("\1"); two_word_flags+=("\1")/' \
 	-e 's/must_have_one_flag+=("\(--.*\)=")/must_have_one_flag+=("\1")/' \


### PR DESCRIPTION
**What this PR does / why we need it**:

zsh completions could not be sourced on ZSH version 4 and above. 

Sourcing led to a `unknown file attribute` error as further explained in
http://stackoverflow.com/questions/37220495/zsh-unknown-file-attribute
